### PR TITLE
Increase jupyterhub start timeout value in values.yaml

### DIFF
--- a/jupyterhub/chart/values.yaml
+++ b/jupyterhub/chart/values.yaml
@@ -387,7 +387,7 @@ singleuser:
     tag: "2.0.0"
     pullPolicy:
     pullSecrets: []
-  startTimeout: 300
+  startTimeout: 1200
   cpu:
     limit:
     guarantee:


### PR DESCRIPTION
Increased the start timeout of JupiterHub containers, because when we start a new container and there are not enough resources, the Kubernetes cluster autoscales, but it takes some time.